### PR TITLE
Update linker script to be consistent with RAM size.

### DIFF
--- a/src/jdsimple.h
+++ b/src/jdsimple.h
@@ -4,7 +4,7 @@
 #ifndef __JDSIMPLE_H
 #define __JDSIMPLE_H
 
-#define DEVICE_DMESG_BUFFER_SIZE 1024
+#define DEVICE_DMESG_BUFFER_SIZE 512
 
 #include <stdint.h>
 #include <string.h>

--- a/targets/f030/linker.ld
+++ b/targets/f030/linker.ld
@@ -33,7 +33,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20002000;    /* end of RAM */
+_estack = 0x20001000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
@@ -41,7 +41,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 6K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 4K
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 32K
 }
 


### PR DESCRIPTION
Hi @mmoskal 

I think there's a bug in the linker script here that's stopping the correct build of this repo for the STM32F030C6.  The linker script initializes with _estack above the top of usable memory, causing an immediate hardfault on execution.

This patch reduces the RAM footprint down to 4K, which puts it in range of the STM32F030C6, largely by reducing the DMESG buffer down to 512 bytes.

I suspect this will also fix the issue recently raised by @fabianhugo

Best,
Joe